### PR TITLE
improvements to listing GH teams/members

### DIFF
--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -17,7 +17,10 @@
 list_team_members <- function(team, org = "openscapes", names_only = TRUE, ...) {
   check_gh_pat()
 
-  org_teams <- list_teams(org)
+  team <- tolower(team)
+  org <- tolower(org)
+  org_teams <- tolower(list_teams(org))
+  
 
   if (!team %in% org_teams) {
     stop("'", team, "' is not part of the '", org, "' organization", 

--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -20,7 +20,6 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE, ...) 
   team <- tolower(team)
   org <- tolower(org)
   org_teams <- tolower(list_teams(org))
-  
 
   if (!team %in% org_teams) {
     stop("'", team, "' is not part of the '", org, "' organization", 
@@ -31,7 +30,8 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE, ...) 
     "GET /orgs/{org}/teams/{team_slug}/members",
     org = org,
     team_slug = team,
-    ...
+    ..., 
+    .limit = Inf
   )
 
   if (!names_only) return(team_members)
@@ -57,7 +57,7 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE, ...) 
 list_teams <- function(org = "openscapes", names_only = TRUE, ...) {
   check_gh_pat()
     
-  teams <- gh("GET /orgs/{org}/teams", org = org)
+  teams <- gh("GET /orgs/{org}/teams", org = org, ..., .limit = Inf)
   
   if (!names_only) return(teams)
 

--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -1,25 +1,33 @@
 #' List members of a GitHub Team
 #'
 #' @inheritParams add_team_members
-#' @param names_only Should only the team member names be returned (as a character vector; `TRUE`, the default),
-#'     or should all of the team member metadata be returned?
+#' @param names_only Should only the team member names be returned (as a
+#'   character vector; `TRUE`, the default), or should all of the team member
+#'   metadata be returned?
+#' @param members Should current members (`"members"`) be returned, or pending
+#'   invitations (`"invitations"`) invitations be returned? Default `"members"`.
 #' @param ... passed on to [gh::gh()]
 #'
-#' @return a character vector of team member GitHub usernames if `names_only = TRUE`, otherwise
-#'    a `gh_response` object containing team member information
+#' @return a character vector of team member GitHub usernames if `names_only =
+#'   TRUE`, otherwise a `gh_response` object containing team member information
 #' @export
 #'
 #' @examples
 #' \dontrun{
 #'   list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes")
-#'   list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes", names_only = FALSE)
+#'   list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes", 
+#'                     names_only = FALSE)
+#'   list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes", 
+#'                     members = "invitations")
 #' }
-list_team_members <- function(team, org = "openscapes", names_only = TRUE, ...) {
+list_team_members <- function(team, org = "openscapes", names_only = TRUE, 
+                              members = c("members", "invitations"), ...) {
   check_gh_pat()
 
   team <- tolower(team)
   org <- tolower(org)
   org_teams <- tolower(list_teams(org))
+  members <- match.arg(members)
 
   if (!team %in% org_teams) {
     stop("'", team, "' is not part of the '", org, "' organization", 
@@ -27,9 +35,10 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE, ...) 
   }
 
   team_members <- gh(
-    "GET /orgs/{org}/teams/{team_slug}/members",
+    "GET /orgs/{org}/teams/{team_slug}/{members}",
     org = org,
     team_slug = team,
+    members = members,
     ..., 
     .limit = Inf
   )

--- a/man/list_team_members.Rd
+++ b/man/list_team_members.Rd
@@ -4,21 +4,30 @@
 \alias{list_team_members}
 \title{List members of a GitHub Team}
 \usage{
-list_team_members(team, org = "openscapes", names_only = TRUE, ...)
+list_team_members(
+  team,
+  org = "openscapes",
+  names_only = TRUE,
+  members = c("members", "invitations"),
+  ...
+)
 }
 \arguments{
 \item{team}{The name of the team.}
 
 \item{org}{The GitHub organization that owns the team and the repository.}
 
-\item{names_only}{Should only the team member names be returned (as a character vector; \code{TRUE}, the default),
-or should all of the team member metadata be returned?}
+\item{names_only}{Should only the team member names be returned (as a
+character vector; \code{TRUE}, the default), or should all of the team member
+metadata be returned?}
+
+\item{members}{Should current members (\code{"members"}) be returned, or pending
+invitations (\code{"invitations"}) invitations be returned? Default \code{"members"}.}
 
 \item{...}{passed on to \code{\link[gh:gh]{gh::gh()}}}
 }
 \value{
-a character vector of team member GitHub usernames if \code{names_only = TRUE}, otherwise
-a \code{gh_response} object containing team member information
+a character vector of team member GitHub usernames if \code{names_only = TRUE}, otherwise a \code{gh_response} object containing team member information
 }
 \description{
 List members of a GitHub Team


### PR DESCRIPTION
In the first version of `list_team_members()` it only returned the first 30 members. This is because there is a 30 record limit in the GH API, beyond which you need to paginate. Setting `.limit = Inf` enables automatic pagination to get all records. This seems safe enough here as we're not ever going to get too many members for it to be a problem.

This PR also makes specifying org and team names in `list_team_members()` case insensitive, which will make it less prone to error unnecessarily. The API is not case sensitive.

Finally, this PR adds the ability to get pending invitations via the new `members` argument in `list_team_members()` (e.g., `list_team_members(team = "longtermaccess2i2c", org = "nasa-openscapes", members = "invitations"`).