### PR TITLE
Gh teams improvements

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,6 +11,8 @@ name: R-CMD-check
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+    
+    
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
@@ -25,7 +27,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GH_PAT }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     cli,
     dplyr,

--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -26,10 +26,10 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE,
 
   team <- tolower(team)
   org <- tolower(org)
-  org_teams <- tolower(list_teams(org))
+  org_teams <- list_teams(org, names_only = FALSE)
   members <- match.arg(members)
 
-  if (!team %in% org_teams) {
+  if (!team %in% org_teams$slug) {
     stop("'", team, "' is not part of the '", org, "' organization", 
          call. = FALSE)
   }
@@ -68,7 +68,7 @@ list_teams <- function(org = "openscapes", names_only = TRUE, ...) {
     
   teams <- gh("GET /orgs/{org}/teams", org = org, ..., .limit = Inf)
   
-  if (!names_only) return(teams)
+  if (!names_only) return(dplyr::bind_rows(teams))
 
   vapply(teams, `[[`, FUN.VALUE = character(1), "name")
 }

--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -52,7 +52,7 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE,
 #'
 #' @inheritParams list_team_members
 #' @param names_only Should only the team names be returned (as a character vector; `TRUE`, the default),
-#'     or should all of the team metadata be returned?
+#'     or should all of the team metadata be returned as a data frame?
 #'
 #' @return a character vector of team names if `names_only = TRUE`, otherwise
 #'    a `gh_response` object containing team information

--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -3,7 +3,7 @@
 #' @inheritParams add_team_members
 #' @param names_only Should only the team member names be returned (as a
 #'   character vector; `TRUE`, the default), or should all of the team member
-#'   metadata be returned?
+#'   metadata be returned as a data.frame?
 #' @param members Should current members (`"members"`) be returned, or pending
 #'   invitations (`"invitations"`) invitations be returned? Default `"members"`.
 #' @param ... passed on to [gh::gh()]
@@ -43,7 +43,7 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE,
     .limit = Inf
   )
 
-  if (!names_only) return(team_members)
+  if (!names_only) return(dplyr::bind_rows(team_members))
     
   vapply(team_members, `[[`, FUN.VALUE = character(1), "login")
 }

--- a/man/list_team_members.Rd
+++ b/man/list_team_members.Rd
@@ -35,6 +35,9 @@ List members of a GitHub Team
 \examples{
 \dontrun{
   list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes")
-  list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes", names_only = FALSE)
+  list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes", 
+                    names_only = FALSE)
+  list_team_members(team = "2023-superdogs-test-cohort", org = "openscapes", 
+                    members = "invitations")
 }
 }

--- a/man/list_team_members.Rd
+++ b/man/list_team_members.Rd
@@ -19,7 +19,7 @@ list_team_members(
 
 \item{names_only}{Should only the team member names be returned (as a
 character vector; \code{TRUE}, the default), or should all of the team member
-metadata be returned?}
+metadata be returned as a data.frame?}
 
 \item{members}{Should current members (\code{"members"}) be returned, or pending
 invitations (\code{"invitations"}) invitations be returned? Default \code{"members"}.}

--- a/man/list_teams.Rd
+++ b/man/list_teams.Rd
@@ -10,7 +10,7 @@ list_teams(org = "openscapes", names_only = TRUE, ...)
 \item{org}{The GitHub organization that owns the team and the repository.}
 
 \item{names_only}{Should only the team names be returned (as a character vector; \code{TRUE}, the default),
-or should all of the team metadata be returned?}
+or should all of the team metadata be returned as a data frame?}
 
 \item{...}{passed on to \code{\link[gh:gh]{gh::gh()}}}
 }

--- a/tests/testthat/_snaps/list_teams.md
+++ b/tests/testthat/_snaps/list_teams.md
@@ -1,0 +1,8 @@
+# list_team_members fails with non-existent team
+
+    Code
+      list_team_members("foofy")
+    Condition
+      Error:
+      ! 'foofy' is not part of the 'openscapes' organization
+

--- a/tests/testthat/test-list_teams.R
+++ b/tests/testthat/test-list_teams.R
@@ -1,0 +1,28 @@
+test_that("list_teams works", {
+  expect_type(
+    list_teams(names_only = TRUE),
+    "character"
+  )
+  expect_s3_class(
+    list_teams(names_only = FALSE),
+    "data.frame"
+  )
+})
+
+test_that("list_team_members works", {
+  expect_type(
+    list_team_members("core-team"),
+    "character"
+  )
+  expect_s3_class(
+    list_team_members("core-team", names_only = FALSE),
+    "data.frame"
+  )
+})
+
+test_that("list_team_members fails with non-existent team", {
+  expect_snapshot(
+    list_team_members("foofy"),
+    error = TRUE
+  )
+})


### PR DESCRIPTION
Sometimes we need more metadata about a team or a member than than just the name (especially the slug, in the case of `list_team_members()`), so this allows returning a data frame of team metadata from `list_teams()` and `list_team_members()`, rather than the raw `gh` response or a character vector of names.

This is used in `list_team_members()` to validate the supplied team against the slug.