### PR TITLE
teams with parents show up as one row

### DIFF
--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -66,7 +66,13 @@ list_team_members <- function(team, org = "openscapes", names_only = TRUE,
 list_teams <- function(org = "openscapes", names_only = TRUE, ...) {
   check_gh_pat()
     
-  teams <- gh("GET /orgs/{org}/teams", org = org, ..., .limit = Inf)
+  teams <- gh("GET /orgs/{org}/teams", org = org, ..., .limit = Inf) %>%
+    purrr::map(function(x) {
+      if(!is.null(x[["parent"]])) {
+        x[["parent"]] <- x[["parent"]][["name"]]
+      }
+      x
+    })
   
   if (!names_only) return(dplyr::bind_rows(teams))
 

--- a/tests/testthat/test-list_teams.R
+++ b/tests/testthat/test-list_teams.R
@@ -7,6 +7,8 @@ test_that("list_teams works", {
     list_teams(names_only = FALSE),
     "data.frame"
   )
+  expect_equal(length(list_teams(names_only = TRUE)), 
+               nrow(list_teams(names_only = FALSE)))
 })
 
 test_that("list_team_members works", {


### PR DESCRIPTION
Reprex: 

With `gh-teams-improvements` [4446e1e](https://github.com/Openscapes/kyber/pull/139/commits/4446e1e81f3bc22745b86d7133a6e2dfc13dd3e3):

```r
kyber::list_teams(org = "openscapes", names_only = FALSE) %>% knitr::kable()
```

```
|name                          |       id|node_id              |slug                          |description                                                                                                            |privacy |notification_setting  |url                                                         |html_url                                                               |members_url                                                                  |repositories_url                                                  |permission |parent                                                                      |
|:-----------------------------|--------:|:--------------------|:-----------------------------|:----------------------------------------------------------------------------------------------------------------------|:-------|:---------------------|:-----------------------------------------------------------|:----------------------------------------------------------------------|:----------------------------------------------------------------------------|:-----------------------------------------------------------------|:----------|:---------------------------------------------------------------------------|
|2021-fdd-team                 |  5138359|T_kwDOAmuozc4ATme3   |2021-fdd-team                 |FDD Cohort                                                                                                             |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5138359  |https://github.com/orgs/Openscapes/teams/2021-fdd-team                 |https://api.github.com/organizations/40609997/team/5138359/members{/member}  |https://api.github.com/organizations/40609997/team/5138359/repos  |pull       |NULL                                                                        |
|2021-noaa-nmfs-team           |  5138323|T_kwDOAmuozc4ATmeT   |2021-noaa-nmfs-team           |NOAA NMFS Cohort                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5138323  |https://github.com/orgs/Openscapes/teams/2021-noaa-nmfs-team           |https://api.github.com/organizations/40609997/team/5138323/members{/member}  |https://api.github.com/organizations/40609997/team/5138323/repos  |pull       |NULL                                                                        |
|2021-sasi                     |  5114767|T_kwDOAmuozc4ATguP   |2021-sasi                     |SASI Openscapes Champions                                                                                              |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5114767  |https://github.com/orgs/Openscapes/teams/2021-sasi                     |https://api.github.com/organizations/40609997/team/5114767/members{/member}  |https://api.github.com/organizations/40609997/team/5114767/repos  |pull       |NULL                                                                        |
|2022-nasa-champions-team      |  5814980|T_kwDOAmuozc4AWLrE   |2022-nasa-champions-team      |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5814980  |https://github.com/orgs/Openscapes/teams/2022-nasa-champions-team      |https://api.github.com/organizations/40609997/team/5814980/members{/member}  |https://api.github.com/organizations/40609997/team/5814980/repos  |pull       |NULL                                                                        |
|2022-noaa-afsc-assist         |  5387871|T_kwDOAmuozc4AUjZf   |2022-noaa-afsc-assist         |                                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5387871  |https://github.com/orgs/Openscapes/teams/2022-noaa-afsc-assist         |https://api.github.com/organizations/40609997/team/5387871/members{/member}  |https://api.github.com/organizations/40609997/team/5387871/repos  |pull       |NULL                                                                        |
|2022-noaa-afsc-team           |  5629277|T_kwDOAmuozc4AVeVd   |2022-noaa-afsc-team           |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5629277  |https://github.com/orgs/Openscapes/teams/2022-noaa-afsc-team           |https://api.github.com/organizations/40609997/team/5629277/members{/member}  |https://api.github.com/organizations/40609997/team/5629277/repos  |pull       |NULL                                                                        |
|2022-noaa-sefsc-summer-cohort |  6343839|T_kwDOAmuozc4AYMyf   |2022-noaa-sefsc-summer-cohort |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6343839  |https://github.com/orgs/Openscapes/teams/2022-noaa-sefsc-summer-cohort |https://api.github.com/organizations/40609997/team/6343839/members{/member}  |https://api.github.com/organizations/40609997/team/6343839/repos  |pull       |NULL                                                                        |
|2022-swrcb-champions-cohort   |  6565520|T_kwDOAmuozc4AZC6Q   |2022-swrcb-champions-cohort   |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6565520  |https://github.com/orgs/Openscapes/teams/2022-swrcb-champions-cohort   |https://api.github.com/organizations/40609997/team/6565520/members{/member}  |https://api.github.com/organizations/40609997/team/6565520/repos  |pull       |NULL                                                                        |
|2022-swrcb-cohort             |  6566493|T_kwDOAmuozc4AZDJd   |2022-swrcb-cohort             |inaugural Openscapes cohort for the California State Water Resources Control Board, made of members from DWQ and OIMA! |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6566493  |https://github.com/orgs/Openscapes/teams/2022-swrcb-cohort             |https://api.github.com/organizations/40609997/team/6566493/members{/member}  |https://api.github.com/organizations/40609997/team/6566493/repos  |pull       |NULL                                                                        |
|2022-swrcb-mentors            |  6370788|T_kwDOAmuozc4AYTXk   |2022-swrcb-mentors            |                                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6370788  |https://github.com/orgs/Openscapes/teams/2022-swrcb-mentors            |https://api.github.com/organizations/40609997/team/6370788/members{/member}  |https://api.github.com/organizations/40609997/team/6370788/repos  |pull       |NULL                                                                        |
|2023-epa-cohort               |  7526107|T_kwDOAmuozc4Actbb   |2023-epa-cohort               |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/7526107  |https://github.com/orgs/Openscapes/teams/2023-epa-cohort               |https://api.github.com/organizations/40609997/team/7526107/members{/member}  |https://api.github.com/organizations/40609997/team/7526107/repos  |pull       |NULL                                                                        |
|2023-fred-hutch-cohort        |  8536544|T_kwDOAmuozc4AgkHg   |2023-fred-hutch-cohort        |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/8536544  |https://github.com/orgs/Openscapes/teams/2023-fred-hutch-cohort        |https://api.github.com/organizations/40609997/team/8536544/members{/member}  |https://api.github.com/organizations/40609997/team/8536544/repos  |pull       |NULL                                                                        |
|2023-superdogs-test-cohort    |  7892400|T_kwDOAmuozc4AeG2w   |2023-superdogs-test-cohort    |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/7892400  |https://github.com/orgs/Openscapes/teams/2023-superdogs-test-cohort    |https://api.github.com/organizations/40609997/team/7892400/members{/member}  |https://api.github.com/organizations/40609997/team/7892400/repos  |pull       |NULL                                                                        |
|2023-swrcb-cohort             |  8409247|T_kwDOAmuozc4AgFCf   |2023-swrcb-cohort             |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/8409247  |https://github.com/orgs/Openscapes/teams/2023-swrcb-cohort             |https://api.github.com/organizations/40609997/team/8409247/members{/member}  |https://api.github.com/organizations/40609997/team/8409247/repos  |pull       |NULL                                                                        |
|2024-epa-cohort               |  9981148|T_kwDOAmuozc4AmEzc   |2024-epa-cohort               |Openscapes Champions Cohort for the for the EPA Center for Environmental Measurement and Modeling (CEMM)               |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/9981148  |https://github.com/orgs/Openscapes/teams/2024-epa-cohort               |https://api.github.com/organizations/40609997/team/9981148/members{/member}  |https://api.github.com/organizations/40609997/team/9981148/repos  |pull       |NULL                                                                        |
|2024-swrcb-fall-cohort        | 10641667|T_kwDOAmuozc4AomED   |2024-swrcb-fall-cohort        |California Water Boards Openscapes Champions Cohort, Fall 2024                                                         |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/10641667 |https://github.com/orgs/Openscapes/teams/2024-swrcb-fall-cohort        |https://api.github.com/organizations/40609997/team/10641667/members{/member} |https://api.github.com/organizations/40609997/team/10641667/repos |pull       |NULL                                                                        |
|2024-swrcb-spring-cohort      |  9458449|T_kwDOAmuozc4AkFMR   |2024-swrcb-spring-cohort      |California Water Boards Openscapes Champions Cohort, Spring 2024                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/9458449  |https://github.com/orgs/Openscapes/teams/2024-swrcb-spring-cohort      |https://api.github.com/organizations/40609997/team/9458449/members{/member}  |https://api.github.com/organizations/40609997/team/9458449/repos  |pull       |NULL                                                                        |
|assist-fdd                    |  5123667|T_kwDOAmuozc4ATi5T   |assist-fdd                    |Openscapes team leading FDD Cohort                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5123667  |https://github.com/orgs/Openscapes/teams/assist-fdd                    |https://api.github.com/organizations/40609997/team/5123667/members{/member}  |https://api.github.com/organizations/40609997/team/5123667/repos  |pull       |NULL                                                                        |
|assist-noaa-nmfs              |  5123646|T_kwDOAmuozc4ATi4-   |assist-noaa-nmfs              |Openscapes team leading noaa-nmfs                                                                                      |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5123646  |https://github.com/orgs/Openscapes/teams/assist-noaa-nmfs              |https://api.github.com/organizations/40609997/team/5123646/members{/member}  |https://api.github.com/organizations/40609997/team/5123646/repos  |pull       |NULL                                                                        |
|assist-sasi                   |  5124614|T_kwDOAmuozc4ATjIG   |assist-sasi                   |Team co-leading the SASI cohort                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5124614  |https://github.com/orgs/Openscapes/teams/assist-sasi                   |https://api.github.com/organizations/40609997/team/5124614/members{/member}  |https://api.github.com/organizations/40609997/team/5124614/repos  |pull       |NULL                                                                        |
|core-team                     |  5038344|T_kwDOAmuozc4ATOEI   |core-team                     |                                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5038344  |https://github.com/orgs/Openscapes/teams/core-team                     |https://api.github.com/organizations/40609997/team/5038344/members{/member}  |https://api.github.com/organizations/40609997/team/5038344/repos  |pull       |NULL                                                                        |
|CSS Cohort                    |  4828373|MDQ6VGVhbTQ4MjgzNzM= |css-cohort                    |CS&S Cohort Team                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/4828373  |https://github.com/orgs/Openscapes/teams/css-cohort                    |https://api.github.com/organizations/40609997/team/4828373/members{/member}  |https://api.github.com/organizations/40609997/team/4828373/repos  |pull       |NULL                                                                        |
|CSU-COAST                     |  4828789|MDQ6VGVhbTQ4Mjg3ODk= |csu-coast                     |CSU-COAST Cohort                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/4828789  |https://github.com/orgs/Openscapes/teams/csu-coast                     |https://api.github.com/organizations/40609997/team/4828789/members{/member}  |https://api.github.com/organizations/40609997/team/4828789/repos  |pull       |NULL                                                                        |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |2021-noaa-nmfs-team                                                         |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |5138323                                                                     |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |T_kwDOAmuozc4ATmeT                                                          |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |2021-noaa-nmfs-team                                                         |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |NOAA NMFS Cohort                                                            |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |closed                                                                      |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |notifications_enabled                                                       |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |https://api.github.com/organizations/40609997/team/5138323                  |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |https://github.com/orgs/Openscapes/teams/2021-noaa-nmfs-team                |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |https://api.github.com/organizations/40609997/team/5138323/members{/member} |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |https://api.github.com/organizations/40609997/team/5138323/repos            |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |pull                                                                        |
```

With `ghti-fix` [471d11e](https://github.com/Openscapes/kyber/pull/142/commits/471d11e4eed672db5305738b1e5b1a38cbf0de2a):

```
|name                          |       id|node_id              |slug                          |description                                                                                                            |privacy |notification_setting  |url                                                         |html_url                                                               |members_url                                                                  |repositories_url                                                  |permission |parent              |
|:-----------------------------|--------:|:--------------------|:-----------------------------|:----------------------------------------------------------------------------------------------------------------------|:-------|:---------------------|:-----------------------------------------------------------|:----------------------------------------------------------------------|:----------------------------------------------------------------------------|:-----------------------------------------------------------------|:----------|:-------------------|
|2021-fdd-team                 |  5138359|T_kwDOAmuozc4ATme3   |2021-fdd-team                 |FDD Cohort                                                                                                             |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5138359  |https://github.com/orgs/Openscapes/teams/2021-fdd-team                 |https://api.github.com/organizations/40609997/team/5138359/members{/member}  |https://api.github.com/organizations/40609997/team/5138359/repos  |pull       |NA                  |
|2021-noaa-nmfs-team           |  5138323|T_kwDOAmuozc4ATmeT   |2021-noaa-nmfs-team           |NOAA NMFS Cohort                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5138323  |https://github.com/orgs/Openscapes/teams/2021-noaa-nmfs-team           |https://api.github.com/organizations/40609997/team/5138323/members{/member}  |https://api.github.com/organizations/40609997/team/5138323/repos  |pull       |NA                  |
|2021-sasi                     |  5114767|T_kwDOAmuozc4ATguP   |2021-sasi                     |SASI Openscapes Champions                                                                                              |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5114767  |https://github.com/orgs/Openscapes/teams/2021-sasi                     |https://api.github.com/organizations/40609997/team/5114767/members{/member}  |https://api.github.com/organizations/40609997/team/5114767/repos  |pull       |NA                  |
|2022-nasa-champions-team      |  5814980|T_kwDOAmuozc4AWLrE   |2022-nasa-champions-team      |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5814980  |https://github.com/orgs/Openscapes/teams/2022-nasa-champions-team      |https://api.github.com/organizations/40609997/team/5814980/members{/member}  |https://api.github.com/organizations/40609997/team/5814980/repos  |pull       |NA                  |
|2022-noaa-afsc-assist         |  5387871|T_kwDOAmuozc4AUjZf   |2022-noaa-afsc-assist         |                                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5387871  |https://github.com/orgs/Openscapes/teams/2022-noaa-afsc-assist         |https://api.github.com/organizations/40609997/team/5387871/members{/member}  |https://api.github.com/organizations/40609997/team/5387871/repos  |pull       |NA                  |
|2022-noaa-afsc-team           |  5629277|T_kwDOAmuozc4AVeVd   |2022-noaa-afsc-team           |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5629277  |https://github.com/orgs/Openscapes/teams/2022-noaa-afsc-team           |https://api.github.com/organizations/40609997/team/5629277/members{/member}  |https://api.github.com/organizations/40609997/team/5629277/repos  |pull       |NA                  |
|2022-noaa-sefsc-summer-cohort |  6343839|T_kwDOAmuozc4AYMyf   |2022-noaa-sefsc-summer-cohort |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6343839  |https://github.com/orgs/Openscapes/teams/2022-noaa-sefsc-summer-cohort |https://api.github.com/organizations/40609997/team/6343839/members{/member}  |https://api.github.com/organizations/40609997/team/6343839/repos  |pull       |NA                  |
|2022-swrcb-champions-cohort   |  6565520|T_kwDOAmuozc4AZC6Q   |2022-swrcb-champions-cohort   |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6565520  |https://github.com/orgs/Openscapes/teams/2022-swrcb-champions-cohort   |https://api.github.com/organizations/40609997/team/6565520/members{/member}  |https://api.github.com/organizations/40609997/team/6565520/repos  |pull       |NA                  |
|2022-swrcb-cohort             |  6566493|T_kwDOAmuozc4AZDJd   |2022-swrcb-cohort             |inaugural Openscapes cohort for the California State Water Resources Control Board, made of members from DWQ and OIMA! |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6566493  |https://github.com/orgs/Openscapes/teams/2022-swrcb-cohort             |https://api.github.com/organizations/40609997/team/6566493/members{/member}  |https://api.github.com/organizations/40609997/team/6566493/repos  |pull       |NA                  |
|2022-swrcb-mentors            |  6370788|T_kwDOAmuozc4AYTXk   |2022-swrcb-mentors            |                                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/6370788  |https://github.com/orgs/Openscapes/teams/2022-swrcb-mentors            |https://api.github.com/organizations/40609997/team/6370788/members{/member}  |https://api.github.com/organizations/40609997/team/6370788/repos  |pull       |NA                  |
|2023-epa-cohort               |  7526107|T_kwDOAmuozc4Actbb   |2023-epa-cohort               |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/7526107  |https://github.com/orgs/Openscapes/teams/2023-epa-cohort               |https://api.github.com/organizations/40609997/team/7526107/members{/member}  |https://api.github.com/organizations/40609997/team/7526107/repos  |pull       |NA                  |
|2023-fred-hutch-cohort        |  8536544|T_kwDOAmuozc4AgkHg   |2023-fred-hutch-cohort        |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/8536544  |https://github.com/orgs/Openscapes/teams/2023-fred-hutch-cohort        |https://api.github.com/organizations/40609997/team/8536544/members{/member}  |https://api.github.com/organizations/40609997/team/8536544/repos  |pull       |NA                  |
|2023-superdogs-test-cohort    |  7892400|T_kwDOAmuozc4AeG2w   |2023-superdogs-test-cohort    |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/7892400  |https://github.com/orgs/Openscapes/teams/2023-superdogs-test-cohort    |https://api.github.com/organizations/40609997/team/7892400/members{/member}  |https://api.github.com/organizations/40609997/team/7892400/repos  |pull       |NA                  |
|2023-swrcb-cohort             |  8409247|T_kwDOAmuozc4AgFCf   |2023-swrcb-cohort             |NA                                                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/8409247  |https://github.com/orgs/Openscapes/teams/2023-swrcb-cohort             |https://api.github.com/organizations/40609997/team/8409247/members{/member}  |https://api.github.com/organizations/40609997/team/8409247/repos  |pull       |NA                  |
|2024-epa-cohort               |  9981148|T_kwDOAmuozc4AmEzc   |2024-epa-cohort               |Openscapes Champions Cohort for the for the EPA Center for Environmental Measurement and Modeling (CEMM)               |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/9981148  |https://github.com/orgs/Openscapes/teams/2024-epa-cohort               |https://api.github.com/organizations/40609997/team/9981148/members{/member}  |https://api.github.com/organizations/40609997/team/9981148/repos  |pull       |NA                  |
|2024-swrcb-fall-cohort        | 10641667|T_kwDOAmuozc4AomED   |2024-swrcb-fall-cohort        |California Water Boards Openscapes Champions Cohort, Fall 2024                                                         |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/10641667 |https://github.com/orgs/Openscapes/teams/2024-swrcb-fall-cohort        |https://api.github.com/organizations/40609997/team/10641667/members{/member} |https://api.github.com/organizations/40609997/team/10641667/repos |pull       |NA                  |
|2024-swrcb-spring-cohort      |  9458449|T_kwDOAmuozc4AkFMR   |2024-swrcb-spring-cohort      |California Water Boards Openscapes Champions Cohort, Spring 2024                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/9458449  |https://github.com/orgs/Openscapes/teams/2024-swrcb-spring-cohort      |https://api.github.com/organizations/40609997/team/9458449/members{/member}  |https://api.github.com/organizations/40609997/team/9458449/repos  |pull       |NA                  |
|assist-fdd                    |  5123667|T_kwDOAmuozc4ATi5T   |assist-fdd                    |Openscapes team leading FDD Cohort                                                                                     |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5123667  |https://github.com/orgs/Openscapes/teams/assist-fdd                    |https://api.github.com/organizations/40609997/team/5123667/members{/member}  |https://api.github.com/organizations/40609997/team/5123667/repos  |pull       |NA                  |
|assist-noaa-nmfs              |  5123646|T_kwDOAmuozc4ATi4-   |assist-noaa-nmfs              |Openscapes team leading noaa-nmfs                                                                                      |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5123646  |https://github.com/orgs/Openscapes/teams/assist-noaa-nmfs              |https://api.github.com/organizations/40609997/team/5123646/members{/member}  |https://api.github.com/organizations/40609997/team/5123646/repos  |pull       |NA                  |
|assist-sasi                   |  5124614|T_kwDOAmuozc4ATjIG   |assist-sasi                   |Team co-leading the SASI cohort                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5124614  |https://github.com/orgs/Openscapes/teams/assist-sasi                   |https://api.github.com/organizations/40609997/team/5124614/members{/member}  |https://api.github.com/organizations/40609997/team/5124614/repos  |pull       |NA                  |
|core-team                     |  5038344|T_kwDOAmuozc4ATOEI   |core-team                     |                                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5038344  |https://github.com/orgs/Openscapes/teams/core-team                     |https://api.github.com/organizations/40609997/team/5038344/members{/member}  |https://api.github.com/organizations/40609997/team/5038344/repos  |pull       |NA                  |
|CSS Cohort                    |  4828373|MDQ6VGVhbTQ4MjgzNzM= |css-cohort                    |CS&S Cohort Team                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/4828373  |https://github.com/orgs/Openscapes/teams/css-cohort                    |https://api.github.com/organizations/40609997/team/4828373/members{/member}  |https://api.github.com/organizations/40609997/team/4828373/repos  |pull       |NA                  |
|CSU-COAST                     |  4828789|MDQ6VGVhbTQ4Mjg3ODk= |csu-coast                     |CSU-COAST Cohort                                                                                                       |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/4828789  |https://github.com/orgs/Openscapes/teams/csu-coast                     |https://api.github.com/organizations/40609997/team/4828789/members{/member}  |https://api.github.com/organizations/40609997/team/4828789/repos  |pull       |NA                  |
|Eco-Stock Assessment          |  5155570|T_kwDOAmuozc4ATqry   |eco-stock-assessment          |NWFSC Eco-Stock Assessment Team                                                                                        |closed  |notifications_enabled |https://api.github.com/organizations/40609997/team/5155570  |https://github.com/orgs/Openscapes/teams/eco-stock-assessment          |https://api.github.com/organizations/40609997/team/5155570/members{/member}  |https://api.github.com/organizations/40609997/team/5155570/repos  |pull       |2021-noaa-nmfs-team |
```