### PR TITLE
GitHub clinic duplicate names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Imports:
     stringr
 Suggests: 
     testthat (>= 3.0.0),
+    tibble,
     usethis,
     withr
 Config/testthat/edition: 3

--- a/R/create_github_clinic.R
+++ b/R/create_github_clinic.R
@@ -30,8 +30,16 @@ create_github_clinic <- function(names, path = getwd()){
                                  "github_clinic_md_text.md", package = "kyber")
   clinic_path <- fs::path(path, "github-clinic")
   fs::dir_create(clinic_path)
+  file_names <- fs::dir_ls(clinic_path, glob = "*.md")
+
   for (i in names) {
-    fs::file_copy(clinic_template, fs::path(clinic_path, i, ext = "md"))  
+    if (paste0(i, ".md") %in% basename(file_names)) {
+      cli::cli_warn(
+        "A file named {.file {i}.md} already exists. It has prepended with {.code _duplicate_}; please fix manually."
+      )
+      i <- paste0("_duplicate_", i)
+    }
+    fs::file_copy(clinic_template, fs::path(clinic_path, i, ext = "md"))
   }
   invisible(clinic_path)
 }

--- a/R/create_github_clinic.R
+++ b/R/create_github_clinic.R
@@ -1,7 +1,9 @@
 #' Create GitHub Clinic Files
 #'
 #' @param names A vector of names for the markdown files that should be created.
-#' The `.md` extension will be added automatically.
+#' The `.md` extension will be added automatically. The names should be unique.
+#' If there exists a file with the same name in the target directory, the new file
+#' will be prepended with `_duplicate_` and a warning will be issued.
 #' @param path Path to the directory where `github-clinic` should be created.
 #'
 #' @importFrom fs path dir_create file_copy

--- a/R/create_github_clinic.R
+++ b/R/create_github_clinic.R
@@ -17,10 +17,11 @@
 #' list.files("github-clinic")
 #' #> "erin.md"  "julia.md"
 #' }
-create_github_clinic <- function(names, path = getwd()){
-  if(any(duplicated(names))){
-    stop("Each name must be unique. The following names are duplicated: ", 
-         unique(names[duplicated(names)]))
+create_github_clinic <- function(names, path = getwd()) {
+  if (any(duplicated(names))) {
+    cli::cli_abort(
+      "Each name must be unique, but {unique(names[duplicated(names)])} {?is/are} duplicated."
+    )
   }
   
   names <- gsub("^\\s+|\\s+$", "", names)

--- a/R/create_github_clinic.R
+++ b/R/create_github_clinic.R
@@ -3,32 +3,36 @@
 #' @param names A vector of names for the markdown files that should be created.
 #' The `.md` extension will be added automatically.
 #' @param path Path to the directory where `github-clinic` should be created.
-#' 
+#'
 #' @importFrom fs path dir_create file_copy
 #' @export
-#' @examples 
+#' @examples
 #' \dontrun{
-#' 
+#'
 #' create_github_clinic(names = c("julia", "erin"))
-#' 
+#'
 #' file.exists("github-clinic")
 #' #> TRUE
-#' 
+#'
 #' list.files("github-clinic")
 #' #> "erin.md"  "julia.md"
 #' }
 create_github_clinic <- function(names, path = getwd()) {
   if (any(duplicated(names))) {
     cli::cli_abort(
-      "Each name must be unique, but {unique(names[duplicated(names)])} {?is/are} duplicated."
+      "Each name must be unique, but '{unique(names[duplicated(names)])}' {?is/are} duplicated."
     )
   }
-  
+
   names <- gsub("^\\s+|\\s+$", "", names)
   names <- gsub("\\s+", "-", names)
-  
-  clinic_template <- system.file("kyber-templates", 
-                                 "github_clinic_md_text.md", package = "kyber")
+
+  clinic_template <- system.file(
+    "kyber-templates",
+    "github_clinic_md_text.md",
+    package = "kyber"
+  )
+
   clinic_path <- fs::path(path, "github-clinic")
   fs::dir_create(clinic_path)
   file_names <- fs::dir_ls(clinic_path, glob = "*.md")
@@ -42,5 +46,6 @@ create_github_clinic <- function(names, path = getwd()) {
     }
     fs::file_copy(clinic_template, fs::path(clinic_path, i, ext = "md"))
   }
+
   invisible(clinic_path)
 }

--- a/README.md
+++ b/README.md
@@ -155,30 +155,42 @@ The following suggestions aid next steps as of July 14, 2022:
 If you haven't already, clone the Cohort Repo to RStudio (File > New Project > Version Control > Git) , then run the following code. Detailed instructions of what this looks like:
 
 1. Open the cohort repo as a project in RStudio and create a new script (temporary, you'll deleted it but it's a nicer place to work)
-1. Copy the following into the script, then delete the examples "Erin, Julie". You'll keep the `_demo.md`, which is what you'll demo live. 
-2. Go to the ParticipantsList, and copy the 2 first and last columns
-3. Back in RStudio, put your cursor inside the "tribble" parentheses, then, in the Addin menu in the top of RStudio, select "Paste as Tribble"!
-4. Then, double-check the column headers - they are likely not `first` and `last` as is written in the `kyber::short_names` call. The easiest thing is to update the column names in the `kyber::short_names` code before running (for example: `kyber::short_names(cohort$First.Name, cohort$Last.Name)`
+2. Copy the following into the script, then delete the examples "Erin, Julie". You'll keep the `_demo.md`, which is what you'll demo live. 
+3. Go to the ParticipantsList, and copy the 2 first and last columns.
+4. Back in RStudio, put your cursor inside the "tribble" parentheses, then, in the Addin menu in the top of RStudio, select "Paste as Tribble"!
+5. If you have more than one participant list (e.g., from moore than one cohort), copy them individually into separate tibbles, then use `dplyr::bind_rows()` to combine them into one tibble.
+6. Then, double-check the column headers - they are likely not `first` and `last` as is written in the `kyber::short_names` call. The easiest thing is to update the column names in the `kyber::short_names` code before running (for example: `kyber::short_names(cohort$First.Name, cohort$Last.Name)`
 
 
-```
+```r
 library(stringr)
 library(datapasta) # install.packages("datapasta")
 library(kyber) ## remotes::install_github("openscapes/kyber")
 library(here)
 library(fs)
+library(dplyr)
 
-## use `datapasta` addin to vector_tribble these names formatted from the spreadsheet!
-cohort <- c(tibble::tribble(
-                      ~first,             ~last,
-                      "_demo",       "",                      
-                      "Erin",        "Robinson",
-                      "Julie",         "Lowndes"
-               )
+## use `datapasta` addin to vector_tribble these names formatted from the cohort 1 spreadsheet!
+cohort1 <- tibble::tribble(
+  ~first,    ~last,
+  "_demo",   "",                      
+  "Erin",    "Robinson",
+  "Julie",   "Lowndes"
 )
 
-## create .md files for each Champion
-kyber::short_names(cohort$first, cohort$last) |>
+## use `datapasta` addin to vector_tribble these names formatted from the cohort 2spreadsheet!
+cohort2 <- tibble::tribble(
+  ~first,      ~last,                   
+  "Andy",      "Teucher",
+  "Stefanie",  "Butland"
+)
+
+# Combine them into one tibble if you have multiple cohorts
+all_cohorts <- dplyr::bind_rows(cohort1, cohort2)
+
+# Create .md files for each Champion. `short_names()` makes sure duplicated first names
+# are disambiguated with last initial.
+kyber::short_names(all_cohorts$first, all_cohorts$last) |>
    create_github_clinic(here())
    
 ## copy trailhead image into parent folder
@@ -303,4 +315,3 @@ To contribute to Kyber, fork the repo, unchecking the "Copy the main branch only
 - keep adding, committing, and pushing, then when you're ready open a PR
 
 We started using this workflow when the [California Water Boards Openscapes](https://cawaterboarddatacenter.github.io/swrcb-openscapes/) team began using Kyber to create Agendas from some unique source Rmd files. For example, Water Boards Cohort Calls are 2 hours, not the default 1.5 hrs, their lesson order is different from Openscapes Core Lessons, and includes a new lesson on Documentation.
-

--- a/man/create_github_clinic.Rd
+++ b/man/create_github_clinic.Rd
@@ -8,7 +8,9 @@ create_github_clinic(names, path = getwd())
 }
 \arguments{
 \item{names}{A vector of names for the markdown files that should be created.
-The \code{.md} extension will be added automatically.}
+The \code{.md} extension will be added automatically. The names should be unique.
+If there exists a file with the same name in the target directory, the new file
+will be prepended with \verb{_duplicate_} and a warning will be issued.}
 
 \item{path}{Path to the directory where \code{github-clinic} should be created.}
 }

--- a/tests/testthat/_snaps/create_github_clinic.md
+++ b/tests/testthat/_snaps/create_github_clinic.md
@@ -1,0 +1,8 @@
+# Interaction with duplicated names works (#120)
+
+    Code
+      create_github_clinic(kyber::short_names("Stef", "Jones"), dir)
+    Condition
+      Error:
+      ! [EEXIST] Failed to copy '/Users/andy/dev/openscapes/kyber/inst/kyber-templates/github_clinic_md_text.md' to '/var/folders/_f/n9fw7ctx3fqf2ty9ylw502g80000gn/T/Rtmppw0ZIi/github-clinic/stef.md': file already exists
+

--- a/tests/testthat/_snaps/create_github_clinic.md
+++ b/tests/testthat/_snaps/create_github_clinic.md
@@ -1,8 +1,24 @@
-# Interaction with duplicated names works (#120)
+# Fails with duplicate names
+
+    Code
+      create_github_clinic(names = c("julia", "erin", "julia"))
+    Condition
+      Error in `create_github_clinic()`:
+      ! Each name must be unique, but 'julia' is duplicated.
+
+# Interaction with existing file names works (#120)
 
     Code
       create_github_clinic(kyber::short_names("Stef", "Jones"), dir)
     Condition
-      Error:
-      ! [EEXIST] Failed to copy '/Users/andy/dev/openscapes/kyber/inst/kyber-templates/github_clinic_md_text.md' to '/var/folders/_f/n9fw7ctx3fqf2ty9ylw502g80000gn/T/Rtmppw0ZIi/github-clinic/stef.md': file already exists
+      Warning:
+      A file named 'stef.md' already exists. It has prepended with `_duplicate_`; please fix manually.
+
+---
+
+    Code
+      list.files(file.path(dir, "github-clinic"))
+    Output
+      [1] "_duplicate_stef.md" "erin_l.md"          "erin_r.md"         
+      [4] "stef.md"           
 

--- a/tests/testthat/test-create_github_clinic.R
+++ b/tests/testthat/test-create_github_clinic.R
@@ -21,14 +21,10 @@ test_that("Fails with duplicate names", {
 
 test_that("Interaction with existing file names works (#120)", {
   cohort <- tibble::tribble(
-    ~first,
-    ~last,
-    "Erin",
-    "Robinson",
-    "Erin",
-    "Lowndes",
-    "Stef",
-    "Butland"
+    ~first,   ~last,
+    "Erin",   "Robinson",
+    "Erin",   "Lowndes",
+    "Stef",   "Butland"
   )
 
   dir <- withr::local_tempdir()

--- a/tests/testthat/test-create_github_clinic.R
+++ b/tests/testthat/test-create_github_clinic.R
@@ -1,10 +1,42 @@
 test_that("The GitHub Clinic Folder can be created.", {
   temp_dir <- tempdir()
-  clinic_path <- create_github_clinic(path = temp_dir, names = c("julia", "erin"))
+  clinic_path <- create_github_clinic(
+    path = temp_dir,
+    names = c("julia", "erin")
+  )
   result <- all(c("erin.md", "julia.md") %in% list.files(clinic_path))
-  
+
   # clean up
   unlink(clinic_path, recursive = TRUE, force = TRUE)
-  
+
   expect_true(result)
+})
+
+test_that("Interaction with duplicated names works (#120)", {
+  cohort <- tibble::tribble(
+    ~first,
+    ~last,
+    "Erin",
+    "Robinson",
+    "Erin",
+    "Lowndes",
+    "Stef",
+    "Butland"
+  )
+
+  dir <- withr::local_tempdir()
+
+  kyber::short_names(cohort$first, cohort$last) |>
+    create_github_clinic(dir)
+
+  list.files(file.path(dir, "github-clinic"))
+
+  expect_snapshot(
+    kyber::short_names("Stef", "Jones") |>
+      create_github_clinic(dir)
+  )
+
+  expect_snapshot(
+    list.files(file.path(dir, "github-clinic"))
+  )
 })

--- a/tests/testthat/test-create_github_clinic.R
+++ b/tests/testthat/test-create_github_clinic.R
@@ -12,7 +12,14 @@ test_that("The GitHub Clinic Folder can be created.", {
   expect_true(result)
 })
 
-test_that("Interaction with duplicated names works (#120)", {
+test_that("Fails with duplicate names", {
+  expect_snapshot(
+    create_github_clinic(names = c("julia", "erin", "julia")),
+    error = TRUE
+  )
+})
+
+test_that("Interaction with existing file names works (#120)", {
   cohort <- tibble::tribble(
     ~first,
     ~last,


### PR DESCRIPTION
This fixes #120, largely by suggesting a workflow improvement when creating individual `.md` files for the github clinic. Previously if there were people with the same first name (or potentially first name + last initial) in different cohorts, and the github clinic files were created in separate calls to `short_names() |> create_github_clinic()`, it would generate a somewhat obscure error.

The main way to get around this is by combining the the cohorts into a single tibble before calling `short_names() |> create_github_clinic()`. `short_names()` can then deal with all duplicates in one go. This is illustrated in the `README.md` changes.

This PR also adds an additional check to `create_github_clinic()`, where it checks for already existing file names. If it finds them, it prepends `_duplicate_` to the file name when it is created, and it throws a warning telling the user to fix it manually.