### PR TITLE
Make landscape image appear in call 1 agenda welcome

### DIFF
--- a/inst/agendas/_welcome_first.Rmd
+++ b/inst/agendas/_welcome_first.Rmd
@@ -2,7 +2,7 @@
 params:
   start_time: "1:00pm ET"
   duration: 13
-  files: ["screenshot-gdoc-zoom-setup.png", "wheel_of_power_duckworth.jpg"]
+  files: ["openscapes_champions_landscape.png", "screenshot-gdoc-zoom-setup.png", "wheel_of_power_duckworth.jpg"]
 ---
 
 ## Welcome • `r kyber:::fmt_duration(params$start_time, params$duration)`
@@ -52,7 +52,7 @@ params:
 
 -   **Many paths forward, together** (3 min) – Julie
 
-![](openscapes_champions_landscape.png)
+<center>![](openscapes_champions_landscape.png)</center>
 
 *Think about where are you showing up today*
 


### PR DESCRIPTION
This fixes #158. Andy can you please test this by making agenda for Call 1 and confirm you can see the Openscapes landscape image?
- run code below to create `agenda.md`
- knit/preview it as `html` 
- look for image above text "Think about where are you showing up today"

<img width="372" height="290" alt="Screenshot 2025-08-25 at 8 32 01 PM" src="https://github.com/user-attachments/assets/902ff8a3-4081-4396-a886-f74cb5f23950" />


```
library(kyber)
library(googlesheets4)

kyber::call_agenda(
    registry_url = "https://docs.google.com/spreadsheets/d/1Ys9KiTXXmZ_laBoCV2QWEm7AcnGSVQaXvm2xpi4XTSc/edit#gid=942365997", 
    cohort_id = "2024-nmfs-champions-a", 
    call_number = 1)
```