### PR TITLE
Populate cohort name in README.Rmd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Imports:
     purrr,
     rmarkdown,
     rstudioapi,
-    stringr
+    stringr,
+    whisker
 Suggests: 
     testthat (>= 3.0.0),
     tibble,

--- a/R/create_readme.R
+++ b/R/create_readme.R
@@ -1,7 +1,7 @@
 #' Create a README.Rmd from a Kyber Template
 #' 
 #' @inheritParams rmarkdown::draft
-#' 
+#' @param cohort_name The name of the cohort. Defaults to the current working directory name.
 #' @importFrom rmarkdown draft
 #' @importFrom rstudioapi hasFun navigateToFile
 #' @export
@@ -13,7 +13,9 @@
 #' kyber::create_readme()
 #' }
 create_readme <- function(file = "README.Rmd", 
-                             template = "openscapes-cohort-readme", edit = TRUE){
+                          template = "openscapes-cohort-readme", 
+                          cohort_name = basename(getwd()),
+                          edit = TRUE) {
   readme <- rmarkdown::draft(
     file,
     template,
@@ -21,6 +23,10 @@ create_readme <- function(file = "README.Rmd",
     create_dir = FALSE,
     edit = FALSE
   )
+
+  readme_text <- readLines(readme)
+  readme_text <- whisker::whisker.render(readme_text, list(cohort_name = cohort_name))
+  writeLines(readme_text, readme)
   
   file.copy(system.file("agendas", "horst-champions-trailhead.png", package = "kyber"), 
             dirname(file))

--- a/R/init_repo.R
+++ b/R/init_repo.R
@@ -68,6 +68,7 @@ init_repo <- function(name, org = "openscapes", path = getwd(),
     create_readme(
       fs::path(repo_path, "README.Rmd"),
       template,
+      cohort_name = name,
       edit = edit
     )
   }

--- a/inst/rmarkdown/templates/openscapes-cohort-readme/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/openscapes-cohort-readme/skeleton/skeleton.Rmd
@@ -1,6 +1,6 @@
 ---
 params:
-  cohort_name: "Cohort"
+  cohort_name: "{{cohort_name}}"
   cohort_registry: "https://docs.google.com/spreadsheets/d/1Ys9KiTXXmZ_laBoCV2QWEm7AcnGSVQaXvm2xpi4XTSc/"
 output: github_document
 ---
@@ -71,4 +71,3 @@ Andy Teucher (@teucher), Openscapes
 - [**Our path to better science in less time using open data science tools**](https://www.nature.com/articles/s41559-017-0160) (Lowndes et al. 2017) - This describes a marine science team’s transition to open collaborative teamwork. It was the original inspiration for creating the Champions Program and heavily influences the Core Lessons. We’ll ask that everyone participating reads it before our first Cohort Call.
 - [**Supercharge your research: a ten-week plan for open data science**](https://openscapes.github.io/supercharge-research/) (Lowndes et al. 2019) - This was co-authored with the inaugural Champions Cohort, capturing the most valuable take-aways for marine and environmental science early career faculty.
 - [**Shifting institutional culture to develop climate solutions with Open Science**](https://onlinelibrary.wiley.com/doi/10.1002/ece3.11341) (Lowndes et al. 2024) - This was co-authored by Openscapes mentors across organizations – including NASA Earthdata, NOAA Fisheries, EPA, California Water Boards, Pathways to Open Science, Fred Hutch Cancer Center.
-

--- a/man/create_readme.Rd
+++ b/man/create_readme.Rd
@@ -7,6 +7,7 @@
 create_readme(
   file = "README.Rmd",
   template = "openscapes-cohort-readme",
+  cohort_name = basename(getwd()),
   edit = TRUE
 )
 }
@@ -16,6 +17,8 @@ create_readme(
 \item{template}{Template to use as the basis for the draft. This is either
 the full path to a template directory or the name of a template directory
 within the \code{rmarkdown/templates} directory of a package.}
+
+\item{cohort_name}{The name of the cohort. Defaults to the current working directory name.}
 
 \item{edit}{\code{TRUE} to edit the template immediately}
 }


### PR DESCRIPTION
This fills in the cohort name based on the working directory/repo name when creating the `README.Rmd`. It works:

* During repo creation with `init_repo()`
* During standalone README.Rmd creation with `create_readme()`. Defaults to current working directory

Closes #152 