### PR TITLE
Remove parenthetical info from participant names & reorder vignette

### DIFF
--- a/R/create_certificate.R
+++ b/R/create_certificate.R
@@ -58,7 +58,8 @@ create_certificate <- function(
     pathways = kyber_file("certificate-pathways.qmd")
   )
 
-  participant_name <- paste(first_name, last_name)
+  participant_name <- paste(first_name, last_name) |>
+    clean_participant_names()
 
   outfile <- paste0(
     ifelse(
@@ -316,4 +317,10 @@ get_participant_names.data.frame <- function(participants) {
       )
     }
   }
+}
+
+clean_participant_names <- function(names) {
+  names <- gsub("\\(.+\\)", "", names) # trim leading/trailing whitespace
+  names <- gsub("\\s+", " ", names)
+  trimws(names)
 }

--- a/tests/testthat/_snaps/create_certificate.md
+++ b/tests/testthat/_snaps/create_certificate.md
@@ -74,3 +74,12 @@
       [1] "pathways/Certificate_test-pathways-cohort-2024_Firstname-Lastname.pdf"           
       [2] "pathways/Certificate_test-pathways-cohort-2024_Firstname-MiddleName-Lastname.pdf"
 
+# participant names are cleaned (#154)
+
+    Code
+      list.files(tdir, recursive = TRUE)
+    Output
+      [1] "pathways/Certificate_Pathways-to-Open-Science-2024_Firstname-Lastname1.pdf"
+      [2] "pathways/Certificate_Pathways-to-Open-Science-2024_Firstname-Lastname2.pdf"
+      [3] "pathways/Certificate_Pathways-to-Open-Science-2024_Firstname-Lastname3.pdf"
+

--- a/tests/testthat/test-create_certificate.R
+++ b/tests/testthat/test-create_certificate.R
@@ -243,3 +243,36 @@ test_that("create_batch_pathways_certificates works specifying more args", {
     list.files(tdir, recursive = TRUE)
   )
 })
+
+test_that("participant names are cleaned (#154)", {
+  participants <- c(
+    "Firstname Lastname1 (he/him)",
+    "Firstname (she/her) Lastname2",
+    "Firstname Lastname3 (they/them)"
+  )
+
+  expect_equal(
+    clean_participant_names(
+      participants
+    ),
+    paste0(
+      "Firstname Lastname",
+      1:3
+    )
+  )
+
+  tdir <- withr::local_tempdir()
+
+  suppressMessages(
+    create_batch_pathways_certificates(
+      participants = participants,
+      start_date = "2024-01-01",
+      end_date = "2024-02-01",
+      output_dir = file.path(tdir, "pathways")
+    )
+  )
+
+  expect_snapshot(
+    list.files(tdir, recursive = TRUE)
+  )
+})


### PR DESCRIPTION
Partially addresses #154 by removing parenthetical information from participant names, and removing superfluous whitespace.

This is a fairly simple fix, and there are probably other special characters that we _could_ clean, but I don't want to run the risk of potentially butchering real names by (for example) only limiting to ascii alphabetic... and I think the likelihood of that coming up is relatively low.