### PR TITLE
Replace Openscapes and Allison Horst's twitter with bluesky

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,4 +52,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,55 +24,73 @@ export(remove_org_members)
 export(remove_team_members)
 export(short_names)
 import(knitr)
-importFrom(cli,cli_abort)
-importFrom(cli,cli_alert_info)
-importFrom(dplyr,.data)
-importFrom(dplyr,arrange)
-importFrom(dplyr,filter)
-importFrom(dplyr,group_by)
-importFrom(dplyr,group_split)
-importFrom(dplyr,mutate)
-importFrom(dplyr,pull)
-importFrom(dplyr,tibble)
-importFrom(fs,dir_create)
-importFrom(fs,file_copy)
-importFrom(fs,path)
-importFrom(gert,git_add)
-importFrom(gert,git_branch)
-importFrom(gert,git_branch_move)
-importFrom(gert,git_clone)
-importFrom(gert,git_commit)
-importFrom(gert,git_init)
-importFrom(gert,git_push)
-importFrom(gert,git_remote_add)
+importFrom(cli,
+  cli_abort,
+  cli_alert_info
+)
+importFrom(dplyr,
+  .data,
+  arrange,
+  filter,
+  group_by,
+  group_split,
+  mutate,
+  pull,
+  tibble
+)
+importFrom(fs,
+  dir_create,
+  file_copy,
+  path
+)
+importFrom(gert,
+  git_add,
+  git_branch,
+  git_branch_move,
+  git_clone,
+  git_commit,
+  git_init,
+  git_push,
+  git_remote_add
+)
 importFrom(gh,gh)
 importFrom(gitcreds,gitcreds_get)
 importFrom(googlesheets4,read_sheet)
-importFrom(lubridate,as_date)
-importFrom(lubridate,day)
-importFrom(lubridate,dweeks)
-importFrom(lubridate,minutes)
-importFrom(lubridate,month)
-importFrom(lubridate,parse_date_time)
+importFrom(lubridate,
+  as_date,
+  day,
+  dweeks,
+  minutes,
+  month,
+  parse_date_time
+)
 importFrom(magrittr,"%>%")
-importFrom(parsermd,as_ast)
-importFrom(parsermd,as_document)
-importFrom(parsermd,as_tibble)
-importFrom(parsermd,parse_rmd)
-importFrom(purrr,discard)
-importFrom(purrr,keep)
-importFrom(purrr,list_flatten)
-importFrom(purrr,map)
-importFrom(purrr,map_chr)
-importFrom(purrr,map_dbl)
-importFrom(purrr,map_dfr)
-importFrom(purrr,map_lgl)
-importFrom(purrr,safely)
-importFrom(rmarkdown,draft)
-importFrom(rmarkdown,md_document)
-importFrom(rmarkdown,render)
-importFrom(rmarkdown,yaml_front_matter)
-importFrom(rstudioapi,hasFun)
-importFrom(rstudioapi,navigateToFile)
+importFrom(parsermd,
+  as_ast,
+  as_document,
+  as_tibble,
+  parse_rmd
+)
+importFrom(purrr,
+  discard,
+  keep,
+  list_flatten,
+  map,
+  map_chr,
+  map_dbl,
+  map_dfr,
+  map_lgl,
+  safely
+)
+importFrom(rmarkdown,
+  draft,
+  md_document,
+  render,
+  yaml_front_matter
+)
+importFrom(rstudioapi,
+  hasFun,
+  navigateToFile
+)
 importFrom(stringr,str_extract)
 importFrom(tools,file_ext)

--- a/inst/agendas/_closing.Rmd
+++ b/inst/agendas/_closing.Rmd
@@ -29,7 +29,7 @@ params:
         -   [\@nasa-openscapes](https://github.com/NASA-Openscapes)
     -   mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
     -   bluesky: [openscapes.bsky.social](https://bsky.app/profile/openscapes.bsky.social)
-    -   artwork: by the amazing [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
+    -   artwork: by the amazing [Allison Horst](https://allisonhorst.com/)
 
 -   **Feedback on this session**
 

--- a/inst/agendas/_closing.Rmd
+++ b/inst/agendas/_closing.Rmd
@@ -29,7 +29,7 @@ params:
         -   [\@nasa-openscapes](https://github.com/NASA-Openscapes)
     -   mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
     -   bluesky: [openscapes.bsky.social](https://bsky.app/profile/openscapes.bsky.social)
-    -   artwork: by the amazing [Allison Horst](https://allisonhorst.com/)
+    -   [artwork](https://allisonhorst.com/): by the amazing [Allison Horst](https://github.com/allisonhorst/)
 
 -   **Feedback on this session**
 

--- a/inst/agendas/_closing.Rmd
+++ b/inst/agendas/_closing.Rmd
@@ -29,7 +29,7 @@ params:
         -   [\@nasa-openscapes](https://github.com/NASA-Openscapes)
     -   mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
     -   bluesky: [openscapes.bsky.social](https://bsky.app/profile/openscapes.bsky.social)
-    -   artwork: by the amazing [Allison Horst](https://twitter.com/allison_horst)
+    -   artwork: by the amazing [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
 
 -   **Feedback on this session**
 

--- a/inst/agendas/_inclusion_tip_airtime.Rmd
+++ b/inst/agendas/_inclusion_tip_airtime.Rmd
@@ -5,5 +5,5 @@ params:
 ---
 
 - **Inclusion Tip of the Day** (1 min) – Julie
-  - Good questions to help you think of your airtime (H/T [Kara Woo](https://twitter.com/kara_woo/status/1301577700029546502)):
+  - Good questions to help you think of your airtime (H/T [Kara Woo](https://karawoo.com/)):
     - “Does this need to be said, does it need to be said now, does it need to be said now by me” 

--- a/inst/agendas/_swrcb_closing.Rmd
+++ b/inst/agendas/_swrcb_closing.Rmd
@@ -31,7 +31,7 @@ params:
     -   github: [\@openscapes](https://github.com/openscapes)
         -   [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     -   Mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
-    -   artwork: by the amazing [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
+    -   artwork: by the amazing [Allison Horst](https://allisonhorst.com/)
 -   **Feedback on this session**
     -   What worked? What didn’t? What surprised you? What would you change?
         -   ‎

--- a/inst/agendas/_swrcb_closing.Rmd
+++ b/inst/agendas/_swrcb_closing.Rmd
@@ -31,7 +31,7 @@ params:
     -   github: [\@openscapes](https://github.com/openscapes)
         -   [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     -   Mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
-    -   artwork: by the amazing [Allison Horst](https://twitter.com/allison_horst)
+    -   artwork: by the amazing [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
 -   **Feedback on this session**
     -   What worked? What didn’t? What surprised you? What would you change?
         -   ‎

--- a/inst/agendas/_swrcb_closing.Rmd
+++ b/inst/agendas/_swrcb_closing.Rmd
@@ -31,7 +31,7 @@ params:
     -   github: [\@openscapes](https://github.com/openscapes)
         -   [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     -   Mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
-    -   artwork: by the amazing [Allison Horst](https://allisonhorst.com/)
+    -   [artwork](https://allisonhorst.com/): by the amazing [Allison Horst](https://github.com/allisonhorst/)
 -   **Feedback on this session**
     -   What worked? What didn’t? What surprised you? What would you change?
         -   ‎

--- a/inst/agendas/_swrcb_closing_final.Rmd
+++ b/inst/agendas/_swrcb_closing_final.Rmd
@@ -31,7 +31,7 @@ params:
     -   github: [\@openscapes](https://github.com/openscapes)
         -   [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     -   Mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
-    -   artwork: by the amazing [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
+    -   artwork: by the amazing [Allison Horst](https://allisonhorst.com/)
 -   **Feedback on this session**
     -   What worked? What didn’t? What surprised you? What would you change?
         -   ‎

--- a/inst/agendas/_swrcb_closing_final.Rmd
+++ b/inst/agendas/_swrcb_closing_final.Rmd
@@ -31,7 +31,7 @@ params:
     -   github: [\@openscapes](https://github.com/openscapes)
         -   [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     -   Mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
-    -   artwork: by the amazing [Allison Horst](https://twitter.com/allison_horst)
+    -   artwork: by the amazing [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
 -   **Feedback on this session**
     -   What worked? What didn’t? What surprised you? What would you change?
         -   ‎

--- a/inst/agendas/_swrcb_closing_final.Rmd
+++ b/inst/agendas/_swrcb_closing_final.Rmd
@@ -31,7 +31,7 @@ params:
     -   github: [\@openscapes](https://github.com/openscapes)
         -   [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     -   Mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
-    -   artwork: by the amazing [Allison Horst](https://allisonhorst.com/)
+    -   [artwork](https://allisonhorst.com/): by the amazing [Allison Horst](https://github.com/allisonhorst/)
 -   **Feedback on this session**
     -   What worked? What didn’t? What surprised you? What would you change?
         -   ‎

--- a/inst/agendas/_swrcb_inclusion_tip_airtime.Rmd
+++ b/inst/agendas/_swrcb_inclusion_tip_airtime.Rmd
@@ -5,5 +5,5 @@ params:
 ---
 
 -   **Inclusion Tip of the Day** (2 min) – Anna
-    -   Good questions to help you think of your airtime (H/T [Kara Woo](https://twitter.com/kara_woo/status/1301577700029546502)):
+    -   Good questions to help you think of your airtime (H/T [Kara Woo](https://karawoo.com/)):
         -   “Does this need to be said, does it need to be said now, does it need to be said now by me”

--- a/inst/agendas/agenda-template.Rmd
+++ b/inst/agendas/agenda-template.Rmd
@@ -161,7 +161,7 @@ _All Champions program slides are also linked from [https://openscapes.org/serie
     * github: [@openscapes](https://github.com/openscapes)
         * [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     * Bluesky: [@openscapes](https://bsky.app/profile/openscapes.bsky.social)
-    * artwork: by the incredible [Allison Horst](https://allisonhorst.com/)
+    * [artwork](https://allisonhorst.com/): by the amazing [Allison Horst](https://github.com/allisonhorst/)
 * **Feedback on this session**
     * What worked? What didn’t? What surprised you? What would you change? 
         *  

--- a/inst/agendas/agenda-template.Rmd
+++ b/inst/agendas/agenda-template.Rmd
@@ -7,21 +7,21 @@ library(tidyverse)
 
 ## TODO read in Google Doc registry sheet
 cohort_metadata <- tibble(cohort_name = "2022-faseb",
-                      date_start = "01/28/2021",
-                      time_start = "10:00am PT", 
-                      cohort_type = "core-5calls",
-                      website = "https://openscapes.github.io/2022-faseb",
-                      google_drive_folder = "TODO"
+  date_start = "01/28/2021",
+  time_start = "10:00am PT",
+  cohort_type = "core-5calls",
+  website = "https://openscapes.github.io/2022-faseb",
+  google_drive_folder = "TODO"
 )
 
 
 ## TODO depending on cohort_type, read in Google Doc sheet
 call_metadata <- tibble(call = 1, 
-                    title = "Openscapes Mindset",
-                    opening = "Introductions",
-                    topic1 = "Openscapes Mindset",
-                    topic2 = "Onboarding", 
-                    goals = "We'll start working towards a common understanding...",
+  title = "Openscapes Mindset",
+  opening = "Introductions",
+  topic1 = "Openscapes Mindset",
+  topic2 = "Onboarding",
+  goals = "We'll start working towards a common understanding...",
                     roll-call = "Share something you're good at"
 )
   
@@ -129,7 +129,7 @@ _All Champions program slides are also linked from [https://openscapes.org/serie
 * **Connecting between sessions**
     * https://openscapes.github.io/2021-sasi - details & links
     * Slack
-    * Twitter – [@openscapes](https://twitter.com/openscapes) 
+    * Bluesky – [@openscapes](https://bsky.app/profile/openscapes.bsky.social) 
     * Call Digest next week 
 * **Efficiency Tip of the Day **(3 min) – Julie
 * Keyboard Shortcuts Part 1: Useful for any application (docs, email, code)
@@ -159,8 +159,8 @@ _All Champions program slides are also linked from [https://openscapes.org/serie
         * [/blog](https://openscapes.org/blog): stories from the community
     * github: [@openscapes](https://github.com/openscapes)
         * [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
-    * twitter: [@openscapes](https://twitter.com/openscapes)
-    * artwork: by the incredible [Allison Horst](https://twitter.com/allison_horst)
+    * Bluesky: [@openscapes](https://bsky.app/profile/openscapes.bsky.social)
+    * artwork: by the incredible [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
 * **Feedback on this session**
     * What worked? What didn’t? What surprised you? What would you change? 
         *  

--- a/inst/agendas/agenda-template.Rmd
+++ b/inst/agendas/agenda-template.Rmd
@@ -130,7 +130,8 @@ _All Champions program slides are also linked from [https://openscapes.org/serie
 * **Connecting between sessions**
     * https://openscapes.github.io/2021-sasi - details & links
     * Slack
-    * Bluesky – [@openscapes](https://bsky.app/profile/openscapes.bsky.social) 
+    * Bluesky – [@openscapes](https://bsky.app/profile/openscapes.bsky.social)
+    * Mastodon - [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes) 
     * Call Digest next week 
 * **Efficiency Tip of the Day **(3 min) – Julie
 * Keyboard Shortcuts Part 1: Useful for any application (docs, email, code)
@@ -161,6 +162,7 @@ _All Champions program slides are also linked from [https://openscapes.org/serie
     * github: [@openscapes](https://github.com/openscapes)
         * [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     * Bluesky: [@openscapes](https://bsky.app/profile/openscapes.bsky.social)
+    * Mastodon: [fosstodon.org/\@openscapes](https://fosstodon.org/@openscapes)
     * [artwork](https://allisonhorst.com/): by the amazing [Allison Horst](https://github.com/allisonhorst/)
 * **Feedback on this session**
     * What worked? What didn’t? What surprised you? What would you change? 

--- a/inst/agendas/agenda-template.Rmd
+++ b/inst/agendas/agenda-template.Rmd
@@ -6,7 +6,8 @@ knitr::opts_chunk$set(echo = TRUE)
 library(tidyverse)
 
 ## TODO read in Google Doc registry sheet
-cohort_metadata <- tibble(cohort_name = "2022-faseb",
+cohort_metadata <- tibble(
+  cohort_name = "2022-faseb",
   date_start = "01/28/2021",
   time_start = "10:00am PT",
   cohort_type = "core-5calls",
@@ -16,15 +17,15 @@ cohort_metadata <- tibble(cohort_name = "2022-faseb",
 
 
 ## TODO depending on cohort_type, read in Google Doc sheet
-call_metadata <- tibble(call = 1, 
+call_metadata <- tibble(
+  call = 1,
   title = "Openscapes Mindset",
   opening = "Introductions",
   topic1 = "Openscapes Mindset",
   topic2 = "Onboarding",
   goals = "We'll start working towards a common understanding...",
-                    roll-call = "Share something you're good at"
+  roll_call = "Share something you're good at"
 )
-  
 ```
 
 # Call `r call_metadata$call`: `r call_metadata$title`
@@ -59,7 +60,7 @@ Web: `r cohort_metadata$website`
 
 ## Roll call • `r cohort_metadata$time_start` - `r cohort_metadata$time_start + 2`
 
-_Name / pronouns / [team]() / `r call_metadata$roll-call`
+_Name / pronouns / [team]() / `r call_metadata$roll_call`
 
 * 
 *    
@@ -160,7 +161,7 @@ _All Champions program slides are also linked from [https://openscapes.org/serie
     * github: [@openscapes](https://github.com/openscapes)
         * [how_we_work](https://github.com/Openscapes/how_we_work), [seaside-chats](https://github.com/Openscapes/seaside-chats): Examples from previous cohorts
     * Bluesky: [@openscapes](https://bsky.app/profile/openscapes.bsky.social)
-    * artwork: by the incredible [Allison Horst](https://bsky.app/profile/allisonhorst.bsky.social)
+    * artwork: by the incredible [Allison Horst](https://allisonhorst.com/)
 * **Feedback on this session**
     * What worked? What didn’t? What surprised you? What would you change? 
         *  

--- a/man/kyber-package.Rd
+++ b/man/kyber-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Sean Kross \email{sean@seankross.com} (\href{https://orcid.org/0000-0001-5215-0316}{ORCID})
   \item Julia Lowndes \email{julia@openscapes.org} (\href{https://orcid.org/0000-0003-1682-3872}{ORCID})
   \item Andy Teucher \email{andy.teucher@gmail.com} (\href{https://orcid.org/0000-0002-7840-692X}{ORCID})
   \item Stefanie Butland \email{stefaniebutland@gmail.com} (\href{https://orcid.org/0000-0002-5427-8951}{ORCID})


### PR DESCRIPTION
This replaces twitter with bluesky/website for social media links in the agenda templates. Done for Allison Horst, Kara Woo, and Openscapes.

Closes #173 
Closes #175 
Closes #185 