### PR TITLE
improve agenda outputs messaging and location

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^pkgdown$
 ^[.]?air[.]toml$
 ^\.vscode$
+\.quarto$

--- a/R/add_team_to_repo.R
+++ b/R/add_team_to_repo.R
@@ -19,7 +19,8 @@ add_team_to_repo <- function(repository, team, org = "openscapes") {
     team_slug = team,
     owner = org,
     repo = repository,
-    permission = "push"
+    permission = "push",
+    .progress = FALSE
   )
   invisible(response)
 }

--- a/R/call_agenda.R
+++ b/R/call_agenda.R
@@ -25,7 +25,7 @@ call_agenda <- function(
   call_sheet = "call_metadata",
   website = paste0("https://openscapes.github.io/", cohort_id),
   output_format = md_agenda(),
-  output_file = "agenda.md"
+  output_file = paste0("agenda_call_", call_number, ".md")
 ) {
   cohort_registry <- read_sheet(registry_url, cohort_sheet, col_types = "c")
 

--- a/R/call_agenda.R
+++ b/R/call_agenda.R
@@ -179,6 +179,9 @@ call_agenda <- function(
       lines_[grep("\\\\\\[", lines_)]
     )
     writeLines(lines_, result)
+    cli::cli_alert_success(
+      "Agenda for call {call_number} of cohort {.val {cohort_id}} written to {.file {fs::path_abs(result)}}."
+    )
   } else {
     stop("Agenda output format not supported.")
   }

--- a/R/call_agenda.R
+++ b/R/call_agenda.R
@@ -8,7 +8,7 @@
 #' individual calls.
 #' @param website A website for the cohort.
 #' @param output_format The output format of the agenda.
-#' @param output_file The name of the output file with no file extension.
+#' @param output_file The name of the output file. Defaults to `"agenda_call_[call_number].md"`.
 #' @importFrom googlesheets4 read_sheet
 #' @importFrom tools file_ext
 #' @importFrom purrr keep map_lgl map map_chr map_dfr map_dbl discard list_flatten

--- a/R/create_team.R
+++ b/R/create_team.R
@@ -31,7 +31,8 @@ create_team <- function(name, maintainers, org = "openscapes", visible = TRUE) {
     org = org,
     name = name,
     maintainers = as.list(maintainers),
-    privacy = privacy
+    privacy = privacy,
+    .progress = FALSE
   )
   invisible(response)
 }

--- a/R/init_repo.R
+++ b/R/init_repo.R
@@ -32,7 +32,8 @@ init_repo <- function(
     "GET /orgs/{org}/repos",
     org = org,
     per_page = 100,
-    page = page
+    page = page,
+    .progress = FALSE
   ) %>%
     map_chr(~ .x$"name")
 
@@ -43,7 +44,8 @@ init_repo <- function(
       "GET /orgs/{org}/repos",
       org = org,
       per_page = 100,
-      page = page
+      page = page,
+      .progress = FALSE
     ) %>%
       map_chr(~ .x$"name") %>%
       c(repo_names)

--- a/R/list_teams.R
+++ b/R/list_teams.R
@@ -54,7 +54,9 @@ list_team_members <- function(
     .limit = Inf
   )
 
-  if (!names_only) return(dplyr::bind_rows(team_members))
+  if (!names_only) {
+    return(dplyr::bind_rows(team_members))
+  }
 
   vapply(team_members, `[[`, FUN.VALUE = character(1), "login")
 }
@@ -77,7 +79,13 @@ list_team_members <- function(
 list_teams <- function(org = "openscapes", names_only = TRUE, ...) {
   check_gh_pat()
 
-  teams <- gh("GET /orgs/{org}/teams", org = org, ..., .limit = Inf) %>%
+  teams <- gh(
+    "GET /orgs/{org}/teams",
+    org = org,
+    ...,
+    .limit = Inf,
+    .progress = FALSE
+  ) %>%
     purrr::map(function(x) {
       if (!is.null(x[["parent"]])) {
         x[["parent"]] <- x[["parent"]][["name"]]
@@ -85,7 +93,9 @@ list_teams <- function(org = "openscapes", names_only = TRUE, ...) {
       x
     })
 
-  if (!names_only) return(dplyr::bind_rows(teams))
+  if (!names_only) {
+    return(dplyr::bind_rows(teams))
+  }
 
   vapply(teams, `[[`, FUN.VALUE = character(1), "name")
 }

--- a/man/call_agenda.Rd
+++ b/man/call_agenda.Rd
@@ -12,7 +12,7 @@ call_agenda(
   call_sheet = "call_metadata",
   website = paste0("https://openscapes.github.io/", cohort_id),
   output_format = md_agenda(),
-  output_file = "agenda.md"
+  output_file = paste0("agenda_call_", call_number, ".md")
 )
 }
 \arguments{
@@ -31,7 +31,7 @@ individual calls.}
 
 \item{output_format}{The output format of the agenda.}
 
-\item{output_file}{The name of the output file with no file extension.}
+\item{output_file}{The name of the output file. Defaults to \code{"agenda_call_[call_number].md"}.}
 }
 \description{
 Create a Call Agenda


### PR DESCRIPTION
Agenda doc will now be called `agenda_call_[call-number].md`, and the function will emit a message telling you where it is on your computer.

Closes #187 
Closes #188
Closes #179 